### PR TITLE
assume undetermined row is a record in eval

### DIFF
--- a/src/Interp/Erased.hs
+++ b/src/Interp/Erased.hs
@@ -102,6 +102,7 @@ eval' h (ELabel (Just k) l e) =
   case k of
     Pi -> VRecord [v]
     Sigma -> VVariant 0 v
+    TCUnif _ -> VRecord [v]
   where v = eval h e
 eval' h e0@(EUnlabel (Just k) e l) = -- eval h e
   case (k, v) of


### PR DESCRIPTION
This missing case was causing an error when trying to show a row in the terminal output when it hadn't been determined to be a record or a variant yet.