### PR TITLE
Format with stylish-haskell

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -1,0 +1,481 @@
+# stylish-haskell configuration file
+# ==================================
+
+# The stylish-haskell tool is mainly configured by specifying steps. These steps
+# are a list, so they have an order, and one specific step may appear more than
+# once (if needed). Each file is processed by these steps in the given order.
+steps:
+  # Convert some ASCII sequences to their Unicode equivalents. This is disabled
+  # by default.
+  # - unicode_syntax:
+  #     # In order to make this work, we also need to insert the UnicodeSyntax
+  #     # language pragma. If this flag is set to true, we insert it when it's
+  #     # not already present. You may want to disable it if you configure
+  #     # language extensions using some other method than pragmas. Default:
+  #     # true.
+  #     add_language_pragma: true
+
+  # Format module header
+  #
+  # Currently, this option is not configurable and will format all exports and
+  # module declarations to minimize diffs
+  #
+  # - module_header:
+  #     # How many spaces use for indentation in the module header.
+  #     indent: 4
+  #
+  #     # Should export lists be sorted?  Sorting is only performed within the
+  #     # export section, as delineated by Haddock comments.
+  #     sort: true
+  #
+  #     # See `separate_lists` for the `imports` step.
+  #     separate_lists: true
+  #
+  #     # When to break the "where".
+  #     # Possible values:
+  #     # - exports: only break when there is an explicit export list.
+  #     # - single: only break when the export list counts more than one export.
+  #     # - inline: only break when the export list is too long. This is
+  #     #   determined by the `columns` setting. Not applicable when the export
+  #     #   list contains comments as newlines will be required.
+  #     # - always: always break before the "where".
+  #     break_where: exports
+  #
+  #     # Where to put open bracket
+  #     # Possible values:
+  #     # - same_line: put open bracket on the same line as the module name, before the
+  #     #              comment of the module
+  #     # - next_line: put open bracket on the next line, after module comment
+  #     open_bracket: next_line
+
+  # Format record definitions. This is disabled by default.
+  #
+  # You can control the layout of record fields. The only rules that can't be configured
+  # are these:
+  #
+  # - "|" is always aligned with "="
+  # - "," in fields is always aligned with "{"
+  # - "}" is likewise always aligned with "{"
+  #
+  # - records:
+  #     # How to format equals sign between type constructor and data constructor.
+  #     # Possible values:
+  #     # - "same_line" -- leave "=" AND data constructor on the same line as the type constructor.
+  #     # - "indent N" -- insert a new line and N spaces from the beginning of the next line.
+  #     equals: "indent 2"
+  #
+  #     # How to format first field of each record constructor.
+  #     # Possible values:
+  #     # - "same_line" -- "{" and first field goes on the same line as the data constructor.
+  #     # - "indent N" -- insert a new line and N spaces from the beginning of the data constructor
+  #     first_field: "indent 2"
+  #
+  #     # How many spaces to insert between the column with "," and the beginning of the comment in the next line.
+  #     field_comment: 2
+  #
+  #     # How many spaces to insert before "deriving" clause. Deriving clauses are always on separate lines.
+  #     deriving: 2
+  #
+  #     # How many spaces to insert before "via" clause counted from indentation of deriving clause
+  #     # Possible values:
+  #     # - "same_line" -- "via" part goes on the same line as "deriving" keyword.
+  #     # - "indent N" -- insert a new line and N spaces from the beginning of "deriving" keyword.
+  #     via: "indent 2"
+  #
+  #     # Sort typeclass names in the "deriving" list alphabetically.
+  #     sort_deriving: true
+  #
+  #     # Whether or not to break enums onto several lines
+  #     #
+  #     # Default: false
+  #     break_enums: false
+  #
+  #     # Whether or not to break single constructor data types before `=` sign
+  #     #
+  #     # Default: true
+  #     break_single_constructors: true
+  #
+  #     # Whether or not to curry constraints on function.
+  #     #
+  #     # E.g: @allValues :: Enum a => Bounded a => Proxy a -> [a]@
+  #     #
+  #     # Instead of @allValues :: (Enum a, Bounded a) => Proxy a -> [a]@
+  #     #
+  #     # Default: false
+  #     curried_context: false
+
+  # Align the right hand side of some elements.  This is quite conservative
+  # and only applies to statements where each element occupies a single
+  # line.
+  # Possible values:
+  # - always - Always align statements.
+  # - adjacent - Align statements that are on adjacent lines in groups.
+  # - never - Never align statements.
+  # All default to always.
+  - simple_align:
+      cases: always
+      top_level_patterns: always
+      records: always
+      multi_way_if: always
+
+  # Import cleanup
+  - imports:
+      # There are different ways we can align names and lists.
+      #
+      # - global: Align the import names and import list throughout the entire
+      #   file.
+      #
+      # - file: Like global, but don't add padding when there are no qualified
+      #   imports in the file.
+      #
+      # - group: Only align the imports per group (a group is formed by adjacent
+      #   import lines).
+      #
+      # - none: Do not perform any alignment.
+      #
+      # Default: global.
+      align: global
+
+      # The following options affect only import list alignment.
+      #
+      # List align has following options:
+      #
+      # - after_alias: Import list is aligned with end of import including
+      #   'as' and 'hiding' keywords.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                          init, last, length)
+      #
+      # - with_alias: Import list is aligned with start of alias or hiding.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                 init, last, length)
+      #
+      # - with_module_name: Import list is aligned `list_padding` spaces after
+      #   the module name.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #                          init, last, length)
+      #
+      #   This is mainly intended for use with `pad_module_names: false`.
+      #
+      #   > import qualified Data.List as List (concat, foldl, foldr, head,
+      #                          init, last, length, scanl, scanr, take, drop,
+      #                          sort, nub)
+      #
+      # - new_line: Import list starts always on new line.
+      #
+      #   > import qualified Data.List      as List
+      #   >     (concat, foldl, foldr, head, init, last, length)
+      #
+      # - repeat: Repeat the module name to align the import list.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head)
+      #   > import qualified Data.List      as List (init, last, length)
+      #
+      # Default: after_alias
+      list_align: after_alias
+
+      # Right-pad the module names to align imports in a group:
+      #
+      # - true: a little more readable
+      #
+      #   > import qualified Data.List       as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # - false: diff-safe
+      #
+      #   > import qualified Data.List as List (concat, foldl, foldr, init,
+      #   >                                     last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # Default: true
+      pad_module_names: true
+
+      # Long list align style takes effect when import is too long. This is
+      # determined by 'columns' setting.
+      #
+      # - inline: This option will put as much specs on same line as possible.
+      #
+      # - new_line: Import list will start on new line.
+      #
+      # - new_line_multiline: Import list will start on new line when it's
+      #   short enough to fit to single line. Otherwise it'll be multiline.
+      #
+      # - multiline: One line per import list entry.
+      #   Type with constructor list acts like single import.
+      #
+      #   > import qualified Data.Map as M
+      #   >     ( empty
+      #   >     , singleton
+      #   >     , ...
+      #   >     , delete
+      #   >     )
+      #
+      # Default: inline
+      long_list_align: inline
+
+      # Align empty list (importing instances)
+      #
+      # Empty list align has following options
+      #
+      # - inherit: inherit list_align setting
+      #
+      # - right_after: () is right after the module name:
+      #
+      #   > import Vector.Instances ()
+      #
+      # Default: inherit
+      empty_list_align: inherit
+
+      # List padding determines indentation of import list on lines after import.
+      # This option affects 'long_list_align'.
+      #
+      # - <integer>: constant value
+      #
+      # - module_name: align under start of module name.
+      #   Useful for 'file' and 'group' align settings.
+      #
+      # Default: 4
+      list_padding: 4
+
+      # Separate lists option affects formatting of import list for type
+      # or class. The only difference is single space between type and list
+      # of constructors, selectors and class functions.
+      #
+      # - true: There is single space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable (fold, foldl, foldMap))
+      #
+      # - false: There is no space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable(fold, foldl, foldMap))
+      #
+      # Default: true
+      separate_lists: true
+
+      # Space surround option affects formatting of import lists on a single
+      # line. The only difference is single space after the initial
+      # parenthesis and a single space before the terminal parenthesis.
+      #
+      # - true: There is single space associated with the enclosing
+      #   parenthesis.
+      #
+      #   > import Data.Foo ( foo )
+      #
+      # - false: There is no space associated with the enclosing parenthesis
+      #
+      #   > import Data.Foo (foo)
+      #
+      # Default: false
+      space_surround: false
+
+      # Post qualify option moves any qualifies found in import declarations
+      # to the end of the declaration. This also adjust padding for any
+      # unqualified import declarations.
+      #
+      # - true: Qualified as <module name> is moved to the end of the
+      #   declaration.
+      #
+      #   > import Data.Bar
+      #   > import Data.Foo qualified as F
+      #
+      # - false: Qualified remains in the default location and unqualified
+      #   imports are padded to align with qualified imports.
+      #
+      #   > import           Data.Bar
+      #   > import qualified Data.Foo as F
+      #
+      # Default: false
+      post_qualify: false
+
+      # Automatically group imports based on their module names, with
+      # a blank line separating each group. Groups are ordered in
+      # alphabetical order.
+      #
+      # By default, this groups by the first part of each module's
+      # name (Control.* will be grouped together, Data.*... etc), but
+      # this can be configured with the group_patterns setting.
+      #
+      # When enabled, this rewrites existing blank lines and groups.
+      #
+      # - true: Group imports by the first part of the module name.
+      #
+      #   > import Control.Applicative
+      #   > import Control.Monad
+      #   > import Control.Monad.MonadError
+      #   >
+      #   > import Data.Functor
+      #
+      # - false: Keep import groups as-is (still sorting and
+      #   formatting the imports within each group)
+      #
+      #   > import Control.Monad
+      #   > import Data.Functor
+      #   >
+      #   > import Control.Applicative
+      #   > import Control.Monad.MonadError
+      #
+      # Default: false
+      group_imports: false
+
+      # A list of rules specifying how to group modules and how to
+      # order the groups.
+      #
+      # Each rule has a match field; the rule only applies to module
+      # names matched by this pattern. Patterns are POSIX extended
+      # regular expressions; see the documentation of Text.Regex.TDFA
+      # for details:
+      # https://hackage.haskell.org/package/regex-tdfa-1.3.1.2/docs/Text-Regex-TDFA.html
+      #
+      # Rules are processed in order, so only the *first* rule that
+      # matches a specific module will apply. Any module names that do
+      # not match a single rule will be put into a single group at the
+      # end of the import block.
+      #
+      # Example: group MyApp modules first, with everything else in
+      # one group at the end.
+      #
+      #  group_rules:
+      #    - match: "^MyApp\\>"
+      #
+      #  > import MyApp
+      #  > import MyApp.Foo
+      #  >
+      #  > import Control.Monad
+      #  > import MyApps
+      #  > import Test.MyApp
+      #
+      # A rule can also optionally have a sub_group pattern. Imports
+      # that match the rule will be broken up into further groups by
+      # the part of the module name matched by the sub_group pattern.
+      #
+      # Example: group MyApp modules first, then everything else
+      # sub-grouped by the first part of the module name.
+      #
+      #  group_rules:
+      #    - match: "^MyApp\\>"
+      #    - match: "."
+      #      sub_group: "^[^.]+"
+      #
+      #  > import MyApp
+      #  > import MyApp.Foo
+      #  >
+      #  > import Control.Applicative
+      #  > import Control.Monad
+      #  >
+      #  > import Data.Map
+      #
+      # A pattern only needs to match part of the module name, which
+      # could be in the middle. You can use ^pattern to anchor to the
+      # beginning of the module name, pattern$ to anchor to the end
+      # and ^pattern$ to force a full match. Example:
+      #
+      #  - "Test\\." would match "Test.Foo" and "Foo.Test.Lib"
+      #  - "^Test\\." would match "Test.Foo" but not "Foo.Test.Lib"
+      #  - "\\.Test$" would match "Foo.Test" but not "Foo.Test.Lib"
+      #  - "^Test$" would *only* match "Test"
+      #
+      # You can use \\< and \\> to anchor against the beginning and
+      # end of words, respectively. For example:
+      #
+      #  - "^Test\\." would match "Test.Foo" but not "Test" or "Tests"
+      #  - "^Test\\>" would match "Test.Foo" and "Test", but not
+      #    "Tests"
+      #
+      # The default is a single rule that matches everything and
+      # sub-groups based on the first component of the module name.
+      #
+      # Default: [{ "match" : ".*", "sub_group": "^[^.]+" }]
+      group_rules:
+        - match: ".*"
+          sub_group: "^[^.]+"
+
+  # Language pragmas
+  - language_pragmas:
+      # We can generate different styles of language pragma lists.
+      #
+      # - vertical: Vertical-spaced language pragmas, one per line.
+      #
+      # - compact: A more compact style.
+      #
+      # - compact_line: Similar to compact, but wrap each line with
+      #   `{-# LANGUAGE #-}'.
+      #
+      # - vertical_compact: Similar to vertical, but use only one language pragma.
+      #
+      # Default: vertical.
+      style: vertical
+
+      # Align affects alignment of closing pragma brackets.
+      #
+      # - true: Brackets are aligned in same column.
+      #
+      # - false: Brackets are not aligned together. There is only one space
+      #   between actual import and closing bracket.
+      #
+      # Default: true
+      align: true
+
+      # stylish-haskell can detect redundancy of some language pragmas. If this
+      # is set to true, it will remove those redundant pragmas. Default: true.
+      remove_redundant: true
+
+      # Language prefix to be used for pragma declaration, this allows you to
+      # use other options non case-sensitive like "language" or "Language".
+      # If a non correct String is provided, it will default to: LANGUAGE.
+      language_prefix: LANGUAGE
+
+  # Replace tabs by spaces. This is disabled by default.
+  # - tabs:
+  #     # Number of spaces to use for each tab. Default: 8, as specified by the
+  #     # Haskell report.
+  #     spaces: 8
+
+  # Remove trailing whitespace
+  - trailing_whitespace: {}
+
+  # Squash multiple spaces between the left and right hand sides of some
+  # elements into single spaces. Basically, this undoes the effect of
+  # simple_align but is a bit less conservative.
+  # - squash: {}
+
+# A common setting is the number of columns (parts of) code will be wrapped
+# to. Different steps take this into account.
+#
+# Set this to null to disable all line wrapping.
+#
+# Default: 80.
+columns: 80
+
+# By default, line endings are converted according to the OS. You can override
+# preferred format here.
+#
+# - native: Native newline format. CRLF on Windows, LF on other OSes.
+#
+# - lf: Convert to LF ("\n").
+#
+# - crlf: Convert to CRLF ("\r\n").
+#
+# Default: native.
+newline: native
+
+# Sometimes, language extensions are specified in a cabal file or from the
+# command line instead of using language pragmas in the file. stylish-haskell
+# needs to be aware of these, so it can parse the file correctly.
+#
+# No language extensions are enabled by default.
+# language_extensions:
+  # - TemplateHaskell
+  # - QuasiQuotes
+
+# Attempt to find the cabal file in ancestors of the current directory, and
+# parse options (currently only language extensions) from that.
+#
+# Default: true
+cabal: true

--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -292,7 +292,7 @@ steps:
       #   > import qualified Data.Foo as F
       #
       # Default: false
-      post_qualify: false
+      post_qualify: true
 
       # Automatically group imports based on their module names, with
       # a blank line separating each group. Groups are ordered in
@@ -451,7 +451,7 @@ steps:
 # Set this to null to disable all line wrapping.
 #
 # Default: 80.
-columns: 80
+columns: 200
 
 # By default, line endings are converted according to the OS. You can override
 # preferred format here.
@@ -463,7 +463,7 @@ columns: 80
 # - crlf: Convert to CRLF ("\r\n").
 #
 # Default: native.
-newline: native
+newline: lf
 
 # Sometimes, language extensions are specified in a cabal file or from the
 # command line instead of using language pragmas in the file. stylish-haskell

--- a/src/Agda.hs
+++ b/src/Agda.hs
@@ -1,6 +1,6 @@
 module Agda where
 
-import Syntax
+import           Syntax
 
 render :: Program -> IO String
 render = undefined

--- a/src/Checker.hs
+++ b/src/Checker.hs
@@ -1,18 +1,18 @@
 module Checker (runCheckM, runCheckM', checkTy, checkTop, normalize, TCtxt(..), traceKindInference, traceTypeInference, KBinding(..), typeErrorContext, toCheckM, implicitConstraints) where
 
-import           Control.Monad.Except
-import           Control.Monad.Reader
-import           Control.Monad.State
-import           Control.Monad.Writer
-import           Data.Bifunctor       (second)
+import Control.Monad.Except
+import Control.Monad.Reader
+import Control.Monad.State
+import Control.Monad.Writer
+import Data.Bifunctor       (second)
 
-import           Checker.Monad
-import           Checker.Normalize
-import           Checker.Preds
-import           Checker.Terms
-import           Checker.Types
+import Checker.Monad
+import Checker.Normalize
+import Checker.Preds
+import Checker.Terms
+import Checker.Types
 
-import           Syntax
+import Syntax
 
 third f (a, b, c) = (a, b, f c)
 

--- a/src/Checker.hs
+++ b/src/Checker.hs
@@ -1,18 +1,18 @@
 module Checker (runCheckM, runCheckM', checkTy, checkTop, normalize, TCtxt(..), traceKindInference, traceTypeInference, KBinding(..), typeErrorContext, toCheckM, implicitConstraints) where
 
-import Control.Monad.Except
-import Control.Monad.Reader
-import Control.Monad.State
-import Control.Monad.Writer
-import Data.Bifunctor (second)
+import           Control.Monad.Except
+import           Control.Monad.Reader
+import           Control.Monad.State
+import           Control.Monad.Writer
+import           Data.Bifunctor       (second)
 
-import Checker.Monad
-import Checker.Normalize
-import Checker.Preds
-import Checker.Terms
-import Checker.Types
+import           Checker.Monad
+import           Checker.Normalize
+import           Checker.Preds
+import           Checker.Terms
+import           Checker.Types
 
-import Syntax
+import           Syntax
 
 third f (a, b, c) = (a, b, f c)
 

--- a/src/Checker/Monad.hs
+++ b/src/Checker/Monad.hs
@@ -4,21 +4,19 @@
 
 module Checker.Monad where
 
-import           Control.Monad        (foldM, liftM, liftM2, liftM3,
-                                       mapAndUnzipM, mplus, replicateM, unless,
-                                       when, zipWithM)
-import           Control.Monad.Except
-import           Control.Monad.Reader
-import           Control.Monad.State
-import           Control.Monad.Writer
-import           Data.Bifunctor       (second)
-import           Data.Dynamic
-import           Data.IORef
-import           Data.List            (elemIndex, nub)
-import           GHC.Stack
-import           System.IO.Unsafe     (unsafePerformIO)
+import Control.Monad        (foldM, liftM, liftM2, liftM3, mapAndUnzipM, mplus, replicateM, unless, when, zipWithM)
+import Control.Monad.Except
+import Control.Monad.Reader
+import Control.Monad.State
+import Control.Monad.Writer
+import Data.Bifunctor       (second)
+import Data.Dynamic
+import Data.IORef
+import Data.List            (elemIndex, nub)
+import GHC.Stack
+import System.IO.Unsafe     (unsafePerformIO)
 
-import           Syntax
+import Syntax
 
 {-# NOINLINE traceKindInference #-}
 traceKindInference :: IORef Bool

--- a/src/Checker/Monad.hs
+++ b/src/Checker/Monad.hs
@@ -4,19 +4,21 @@
 
 module Checker.Monad where
 
-import Control.Monad (foldM, liftM, liftM2, liftM3, mapAndUnzipM, mplus, replicateM, unless, when, zipWithM)
-import Control.Monad.Except
-import Control.Monad.Reader
-import Control.Monad.State
-import Control.Monad.Writer
-import Data.Bifunctor (second)
-import Data.Dynamic
-import Data.IORef
-import Data.List (elemIndex, nub)
-import GHC.Stack
-import System.IO.Unsafe (unsafePerformIO)
+import           Control.Monad        (foldM, liftM, liftM2, liftM3,
+                                       mapAndUnzipM, mplus, replicateM, unless,
+                                       when, zipWithM)
+import           Control.Monad.Except
+import           Control.Monad.Reader
+import           Control.Monad.State
+import           Control.Monad.Writer
+import           Data.Bifunctor       (second)
+import           Data.Dynamic
+import           Data.IORef
+import           Data.List            (elemIndex, nub)
+import           GHC.Stack
+import           System.IO.Unsafe     (unsafePerformIO)
 
-import Syntax
+import           Syntax
 
 {-# NOINLINE traceKindInference #-}
 traceKindInference :: IORef Bool
@@ -55,7 +57,7 @@ type TCtxt = [(QName, Ty)]
 type PCtxt = [Pred]
 
 lookupV :: HasCallStack => Int -> TCtxt -> Ty
-lookupV _ [] = error "lookupV: index out of range"
+lookupV _ []           = error "lookupV: index out of range"
 lookupV 0 ((_, t) : _) = t
 lookupV n (_ : ts)     = lookupV (n - 1) ts
 
@@ -222,7 +224,7 @@ instance MonadCheck UnifyM where
 
 canUpdate :: Typeable a => IORef a -> UnifyM Bool
 canUpdate r = UM (ExceptT $ StateT $ \checking -> WriterT (body checking)) where
-  body Nothing = return ((Right True, Nothing), [])
+  body Nothing   = return ((Right True, Nothing), [])
   body (Just rs) = return ((Right (any ok rs), Just rs), [])
   ok dr = case fromDynamic dr of
             Just r' -> r == r'

--- a/src/Checker/Normalize.hs
+++ b/src/Checker/Normalize.hs
@@ -1,15 +1,15 @@
 module Checker.Normalize where
 
-import Control.Monad.Reader
-import Data.Bifunctor (first)
-import Data.List
-import Data.Maybe
+import           Control.Monad.Reader
+import           Data.Bifunctor       (first)
+import           Data.List
+import           Data.Maybe
 
-import Checker.Monad
-import Checker.Utils
-import Syntax
+import           Checker.Monad
+import           Checker.Utils
+import           Syntax
 
-import GHC.Stack
+import           GHC.Stack
 
 
 class HasTyVars t where

--- a/src/Checker/Normalize.hs
+++ b/src/Checker/Normalize.hs
@@ -1,15 +1,15 @@
 module Checker.Normalize where
 
-import           Control.Monad.Reader
-import           Data.Bifunctor       (first)
-import           Data.List
-import           Data.Maybe
+import Control.Monad.Reader
+import Data.Bifunctor       (first)
+import Data.List
+import Data.Maybe
 
-import           Checker.Monad
-import           Checker.Utils
-import           Syntax
+import Checker.Monad
+import Checker.Utils
+import Syntax
 
-import           GHC.Stack
+import GHC.Stack
 
 
 class HasTyVars t where
@@ -53,10 +53,10 @@ instance HasTyVars Ty where
   subst v t u = error $ "internal: subst " ++ show v ++ " (" ++ show t ++ ") (" ++ show u ++")"
 
 instance HasTyVars Pred where
-  subst v t (PEq u u') = PEq <$> subst v t u <*> subst v t u'
-  subst v t (PLeq y z) = PLeq <$> subst v t y <*> subst v t z
+  subst v t (PEq u u')    = PEq <$> subst v t u <*> subst v t u'
+  subst v t (PLeq y z)    = PLeq <$> subst v t y <*> subst v t z
   subst v t (PPlus x y z) = PPlus <$> subst v t x <*> subst v t y <*> subst v t z
-  subst v t (PFold z) = PFold <$> subst v t z
+  subst v t (PFold z)     = PFold <$> subst v t z
 
 normalize' :: (HasCallStack, MonadCheck m) => [Eqn] -> Ty -> m (Ty, Evid)
 normalize' eqns t =
@@ -125,7 +125,7 @@ normalize eqns (TMapApp z) =
     do k <- kindOf z
        case k of
          KRow (KFun k1 k2) -> return (TLam "X" (Just k1) (TApp (TMap (TLam "Y" (Just (KFun k1 k2)) (TApp (TVar 0 ["Y", ""]) (TVar 1 ["X", ""])))) (shiftTN 0 1 z)), VEqDefn)
-         _ -> fail ("normalize: ill-kinded " ++ show (TMapApp z))
+         _                 -> fail ("normalize: ill-kinded " ++ show (TMapApp z))
 normalize eqns (TApp t1 t2) =
   do (t1', q1) <- normalize eqns t1
      q1' <- flattenV q1
@@ -206,7 +206,7 @@ normalize eqns (TThen p t) =
 normalize eqns t = return (t, VEqRefl)
 
 normalizeP :: MonadCheck m => [Eqn] -> Pred -> m Pred -- no evidence structure for predicate equality yet soooo....
-normalizeP eqns (PLeq x y) = PLeq <$> (fst <$> normalize eqns x) <*> (fst <$> normalize eqns y)
+normalizeP eqns (PLeq x y)    = PLeq <$> (fst <$> normalize eqns x) <*> (fst <$> normalize eqns y)
 normalizeP eqns (PPlus x y z) = PPlus <$> (fst <$> normalize eqns x) <*> (fst <$> normalize eqns y) <*> (fst <$> normalize eqns z)
-normalizeP eqns (PEq t u) = PEq <$> (fst <$> normalize' eqns t) <*> (fst <$> normalize' eqns u)
-normalizeP eqns (PFold z) = PFold <$> (fst <$> normalize' eqns z)
+normalizeP eqns (PEq t u)     = PEq <$> (fst <$> normalize' eqns t) <*> (fst <$> normalize' eqns u)
+normalizeP eqns (PFold z)     = PFold <$> (fst <$> normalize' eqns z)

--- a/src/Checker/Preds.hs
+++ b/src/Checker/Preds.hs
@@ -1,32 +1,32 @@
 {-# LANGUAGE ParallelListComp #-}
 module Checker.Preds where
 
-import           Control.Monad
-import           Control.Monad.Error.Class
-import           Control.Monad.Reader.Class
-import           Control.Monad.Writer.Class
-import           Data.Bifunctor
-import           Data.Either                (isLeft, isRight)
-import           Data.IORef
-import           Data.List
-import           Data.Maybe                 (catMaybes)
+import Control.Monad
+import Control.Monad.Error.Class
+import Control.Monad.Reader.Class
+import Control.Monad.Writer.Class
+import Data.Bifunctor
+import Data.Either                (isLeft, isRight)
+import Data.IORef
+import Data.List
+import Data.Maybe                 (catMaybes)
 
-import           Control.Monad.IO.Class
-import           System.IO
+import Control.Monad.IO.Class
+import System.IO
 
 
-import           Checker.Monad
-import           Checker.Normalize
-import           Checker.Promote
-import           Checker.Types              (checkPred)
-import           Checker.Unify
-import           Checker.Utils
-import           Printer
-import           Syntax
+import Checker.Monad
+import Checker.Normalize
+import Checker.Promote
+import Checker.Types              (checkPred)
+import Checker.Unify
+import Checker.Utils
+import Printer
+import Syntax
 
-import           GHC.Stack
+import GHC.Stack
 
-import qualified Debug.Trace                as T
+import Debug.Trace                qualified as T
 
 solve :: HasCallStack => (TCIn, Pred, IORef (Maybe Evid)) -> CheckM Bool
 solve (cin, p, r) =

--- a/src/Checker/Preds.hs
+++ b/src/Checker/Preds.hs
@@ -1,32 +1,32 @@
 {-# LANGUAGE ParallelListComp #-}
 module Checker.Preds where
 
-import Control.Monad
-import Control.Monad.Error.Class
-import Control.Monad.Reader.Class
-import Control.Monad.Writer.Class
-import Data.Bifunctor
-import Data.Either (isLeft, isRight)
-import Data.IORef
-import Data.List
-import Data.Maybe (catMaybes)
+import           Control.Monad
+import           Control.Monad.Error.Class
+import           Control.Monad.Reader.Class
+import           Control.Monad.Writer.Class
+import           Data.Bifunctor
+import           Data.Either                (isLeft, isRight)
+import           Data.IORef
+import           Data.List
+import           Data.Maybe                 (catMaybes)
 
-import Control.Monad.IO.Class
-import System.IO
+import           Control.Monad.IO.Class
+import           System.IO
 
 
-import Checker.Monad
-import Checker.Normalize
-import Checker.Promote
-import Checker.Types (checkPred)
-import Checker.Unify
-import Checker.Utils
-import Printer
-import Syntax
+import           Checker.Monad
+import           Checker.Normalize
+import           Checker.Promote
+import           Checker.Types              (checkPred)
+import           Checker.Unify
+import           Checker.Utils
+import           Printer
+import           Syntax
 
-import GHC.Stack
+import           GHC.Stack
 
-import qualified Debug.Trace as T
+import qualified Debug.Trace                as T
 
 solve :: HasCallStack => (TCIn, Pred, IORef (Maybe Evid)) -> CheckM Bool
 solve (cin, p, r) =
@@ -42,7 +42,7 @@ solve (cin, p, r) =
      trace ("Normalized goal to " ++ show p')
      mv <- everything as'' p'
      case mv of
-       Just v -> writeRef r (Just v) >> return True
+       Just v  -> writeRef r (Just v) >> return True
        Nothing -> return False
 
   where
@@ -61,9 +61,9 @@ solve (cin, p, r) =
 
   pickEqns :: [(Pred, Evid)] -> [Eqn]
   pickEqns ps = go ps where
-    go [] = []
+    go []                             = []
     go ((PEq (TCompl z x) y, v) : ps) = (TCompl z x, (y, v)) : go ps
-    go (_ : ps) = go ps
+    go (_ : ps)                       = go ps
 
   everything as p =
     do trace ("Solving " ++ show p)
@@ -102,8 +102,8 @@ solve (cin, p, r) =
         Just yt ->
           do q <- unify [] xt yt
              case q of
-               Left _ -> fundeps p
-               Right _  -> return ()) xs
+               Left _  -> fundeps p
+               Right _ -> return ()) xs
 
   matchLeqDirect, matchLeqMap, matchPlusDirect, matchPlusMap, matchEqDirect, matchFoldDirect, match :: HasCallStack => Pred -> (Pred, Evid) -> CheckM (Maybe Evid)
   match p q = matchLeqDirect p q <|> matchLeqMap p q <|> matchPlusDirect p q <|> matchPlusMap p q <|> matchEqDirect p q <|> matchFoldDirect p q
@@ -168,7 +168,7 @@ solve (cin, p, r) =
             do q <- unify [] t t'
                case q of
                  Left _ -> fundeps p
-                 _       -> return (Just v)
+                 _      -> return (Just v)
   matchPlusDirect _ _ = return Nothing
 
   {-
@@ -275,14 +275,14 @@ solve (cin, p, r) =
       seen = map fst (qs ++ ps)
       ps' = filter ((`notElem` seen) . fst) (expand1 p ++ concatMap (expand2 p) qs)
 
-  byAssump [] p = return Nothing
+  byAssump [] p       = return Nothing
   byAssump (a : as) p = match p a <|> byAssump as p
 
   force p t u =
     do q <- unify [] t u
        case q of
-         Left _ -> fundeps p
-         Right _  -> return ()
+         Left _  -> fundeps p
+         Right _ -> return ()
 
   prim p@(PLeq (TRow y) (TRow z))
     | Just yd <- mapM concreteLabel y, Just zd <- mapM concreteLabel z =
@@ -299,7 +299,7 @@ solve (cin, p, r) =
           Just is ->
             do mapM_ align (zip is z)
                return (Just (VPlusSimple is))
-    where align (Left i, TLabeled _ t) = force p t u where TLabeled _ u = x !! i
+    where align (Left i, TLabeled _ t)  = force p t u where TLabeled _ u = x !! i
           align (Right i, TLabeled _ t) = force p t u where TLabeled _ u = y !! i
   prim p@(PPlus (TRow x) y (TRow z))
     | Just xs <- mapM splitConcreteLabel x, Just zs <- mapM splitConcreteLabel z, Just is <- mapM (flip elemIndex (map fst zs)) (map fst xs) =
@@ -339,8 +339,8 @@ solve (cin, p, r) =
   prim p@(PEq t u) =
     do result <- unifyProductive [] t u
        case result of
-         Productive v -> return (Just v)
-         Unproductive -> return Nothing
+         Productive v       -> return (Just v)
+         Unproductive       -> return Nothing
          UnificationFails _ -> throwError (ErrTypeMismatchPred p t u)
   prim p@(PFold (TRow xs)) =
     return (Just (VFold (length xs)))
@@ -543,7 +543,7 @@ guesses prs =
       walkIs (Unknown n g) =
         do mis <- readRef (goalRef g)
            case mis of
-             Nothing -> return (Unknown n g)
+             Nothing  -> return (Unknown n g)
              Just is' -> walkIs (shiftIsV [] 0 n is')
       walkI (TyArg t) = TyArg <$> walk x u m t
       walkI (PrArg v) = return (PrArg v)
@@ -690,7 +690,7 @@ guess (pr@(tcin, PEq t u, v) : prs) =
           walkIs (Unknown n g) =
             do mis <- readRef (goalRef g)
                case mis of
-                 Nothing -> return (Unknown n g)
+                 Nothing  -> return (Unknown n g)
                  Just is' -> walkIs (shiftIsV [] 0 n is')
           walkI (TyArg t) = TyArg <$> walk x u m t
           walkI (PrArg v) = return (PrArg v)
@@ -730,7 +730,7 @@ solverLoop ps =
              once (b || b')
                   (if b' then qs else p : qs)
                   (ps ++ ps')
-        guessLoop [] = return ps
+        guessLoop []       = return ps
         guessLoop (g : gs) = solverLoop =<< g
 
 

--- a/src/Checker/Promote.hs
+++ b/src/Checker/Promote.hs
@@ -1,15 +1,15 @@
 module Checker.Promote where
 
-import Control.Monad
-import Control.Monad.Reader
+import           Control.Monad
+import           Control.Monad.Reader
 
-import Checker.Monad
-import Checker.Types hiding (trace)
-import Checker.Utils
-import Printer
-import Syntax
+import           Checker.Monad
+import           Checker.Types        hiding (trace)
+import           Checker.Utils
+import           Printer
+import           Syntax
 
-import GHC.Stack
+import           GHC.Stack
 
 {--
 
@@ -93,7 +93,7 @@ promoteN v@(UV n l _ _) m (TInst is t) = liftM2 TInst <$> promoteIs is <*> promo
                                    return (Just (newIs 0))
         promoteIs (Known is) = liftM Known . sequence <$> mapM promoteI is
         promoteI :: MonadCheck m => Inst -> m (Maybe Inst)
-        promoteI (TyArg t) = liftM TyArg <$> promoteN v n t
+        promoteI (TyArg t)   = liftM TyArg <$> promoteN v n t
         promoteI i@(PrArg v) = return (Just i)
 promoteN v n (TMapApp f) = liftM TMapApp <$> promoteN v n f
 promoteN v n t = error $ "promote: missing " ++ show t

--- a/src/Checker/Promote.hs
+++ b/src/Checker/Promote.hs
@@ -1,15 +1,15 @@
 module Checker.Promote where
 
-import           Control.Monad
-import           Control.Monad.Reader
+import Control.Monad
+import Control.Monad.Reader
 
-import           Checker.Monad
-import           Checker.Types        hiding (trace)
-import           Checker.Utils
-import           Printer
-import           Syntax
+import Checker.Monad
+import Checker.Types        hiding (trace)
+import Checker.Utils
+import Printer
+import Syntax
 
-import           GHC.Stack
+import GHC.Stack
 
 {--
 
@@ -99,10 +99,10 @@ promoteN v n (TMapApp f) = liftM TMapApp <$> promoteN v n f
 promoteN v n t = error $ "promote: missing " ++ show t
 
 promoteP :: MonadCheck m => UVar -> Int -> Pred -> m (Maybe Pred)
-promoteP v n (PEq t u) = liftM2 PEq <$> promoteN v n t <*> promoteN v n u
-promoteP v n (PLeq y z) = liftM2 PLeq <$> promoteN v n y <*> promoteN v n z
+promoteP v n (PEq t u)     = liftM2 PEq <$> promoteN v n t <*> promoteN v n u
+promoteP v n (PLeq y z)    = liftM2 PLeq <$> promoteN v n y <*> promoteN v n z
 promoteP v n (PPlus x y z) = liftM3 PPlus <$> promoteN v n x <*> promoteN v n y <*> promoteN v n z
-promoteP v n (PFold z) = liftM PFold <$> promoteN v n z
+promoteP v n (PFold z)     = liftM PFold <$> promoteN v n z
 
 -- TODO: the Evid returned here is always and only VEqRefl... why needed?
 solveUV :: (HasCallStack, MonadCheck m) => UVar -> Ty -> m (Maybe Evid)

--- a/src/Checker/Terms.hs
+++ b/src/Checker/Terms.hs
@@ -1,22 +1,22 @@
 module Checker.Terms where
 
-import Control.Monad
-import Control.Monad.IO.Class
-import Control.Monad.Error.Class
-import Control.Monad.Reader.Class
-import Control.Monad.Writer.Class
-import Data.Generics (everywhereM, mkM)
-import Data.IORef
-import Data.List (intercalate)
+import           Control.Monad
+import           Control.Monad.Error.Class
+import           Control.Monad.IO.Class
+import           Control.Monad.Reader.Class
+import           Control.Monad.Writer.Class
+import           Data.Generics              (everywhereM, mkM)
+import           Data.IORef
+import           Data.List                  (intercalate)
 
-import Checker.Types hiding (trace, collect)
-import Checker.Unify
-import Checker.Utils
-import Checker.Normalize
-import Checker.Monad
-import Checker.Preds
-import Printer
-import Syntax
+import           Checker.Monad
+import           Checker.Normalize
+import           Checker.Preds
+import           Checker.Types              hiding (collect, trace)
+import           Checker.Unify
+import           Checker.Utils
+import           Printer
+import           Syntax
 
 
 expectT :: Term -> Ty -> Ty -> CheckM Evid
@@ -302,8 +302,8 @@ generalize e =
         uvars level (TMap t) = uvars level t
         uvars level (TInst is t) = cat <$> isuvars is <*> uvars level t where
           isuvars (Unknown {}) = return []
-          isuvars (Known is) = foldl cat [] <$> mapM iuvars is
-          iuvars (TyArg t) = uvars level t
+          isuvars (Known is)   = foldl cat [] <$> mapM iuvars is
+          iuvars (TyArg t)  = uvars level t
           iuvars (PrArg {}) = return []
         uvars level (TMapApp t) = uvars level t
         uvars _ TString = return []
@@ -359,7 +359,7 @@ generalize e =
           fixInst t@(TUnif v) =
             do mu <- readRef (ref v)
                case mu of
-                 Just u -> fixInsts u >> return t
+                 Just u  -> fixInsts u >> return t
                  Nothing -> return t
           fixInst t@(TInst (Unknown _ (Goal (_, iref))) _) =
             do mi <- readRef iref
@@ -374,11 +374,11 @@ generalize e =
           (tyLams ts names (prLams ps e), quantifiers ts names (qualifiers ps t))
           where quantifiers [] _ t = t
                 quantifiers (u : us) (b : bs) t = TForall b (Just (uvKind u)) (quantifiers us bs t)
-                qualifiers [] t = t
+                qualifiers [] t            = t
                 qualifiers ((p, _) : ps) t = TThen p (qualifiers ps t)
                 tyLams [] _ e = e
                 tyLams (u : us) (b : bs) e = ETyLam b (Just (uvKind u)) (tyLams us bs e)
-                prLams [] e = e
+                prLams [] e            = e
                 prLams ((p, _) : ps) e = EPrLam p (prLams ps e)
 
 checkTop :: Term -> Maybe Ty -> CheckM (Term, Ty)

--- a/src/Checker/Terms.hs
+++ b/src/Checker/Terms.hs
@@ -1,22 +1,22 @@
 module Checker.Terms where
 
-import           Control.Monad
-import           Control.Monad.Error.Class
-import           Control.Monad.IO.Class
-import           Control.Monad.Reader.Class
-import           Control.Monad.Writer.Class
-import           Data.Generics              (everywhereM, mkM)
-import           Data.IORef
-import           Data.List                  (intercalate)
+import Control.Monad
+import Control.Monad.Error.Class
+import Control.Monad.IO.Class
+import Control.Monad.Reader.Class
+import Control.Monad.Writer.Class
+import Data.Generics              (everywhereM, mkM)
+import Data.IORef
+import Data.List                  (intercalate)
 
-import           Checker.Monad
-import           Checker.Normalize
-import           Checker.Preds
-import           Checker.Types              hiding (collect, trace)
-import           Checker.Unify
-import           Checker.Utils
-import           Printer
-import           Syntax
+import Checker.Monad
+import Checker.Normalize
+import Checker.Preds
+import Checker.Types              hiding (collect, trace)
+import Checker.Unify
+import Checker.Utils
+import Printer
+import Syntax
 
 
 expectT :: Term -> Ty -> Ty -> CheckM Evid
@@ -25,7 +25,7 @@ expectT m actual expected =
      b <- typeErrorContext (ErrContextTerm m . ErrContextTyEq actual expected) $ unify [] actual expected
      case b of
        Left (actual', expected') -> typeMismatch m actual expected actual' expected'
-       Right q  -> flattenV q
+       Right q                   -> flattenV q
 
 typeMismatch :: Term -> Ty -> Ty -> Ty -> Ty -> CheckM a
 typeMismatch m actual expected actual' expected' =
@@ -111,7 +111,7 @@ checkTerm0 e0@(EInst e is) expected =
        EInst <$> checkTerm e (TInst is' expected) <*> pure is'
   where checkInsts :: Insts -> CheckM Insts
         checkInsts (Unknown _ _) = error "internal: why am I type checking an unknown instantiation?"
-        checkInsts (Known is) = Known <$> mapM checkInst is
+        checkInsts (Known is)    = Known <$> mapM checkInst is
         checkInst :: Inst -> CheckM Inst
         checkInst (TyArg t) =
           do k <- kindGoal "k"
@@ -310,10 +310,10 @@ generalize e =
         uvars level (TCompl t1 t2) = cat <$> uvars level t1 <*> uvars level t2
 
         puvars :: Level -> Pred -> CheckM [UVar]
-        puvars level (PEq t u) = cat <$> uvars level t <*> uvars level u
-        puvars level (PLeq y z) = cat <$> uvars level y <*> uvars level z
+        puvars level (PEq t u)     = cat <$> uvars level t <*> uvars level u
+        puvars level (PLeq y z)    = cat <$> uvars level y <*> uvars level z
         puvars level (PPlus x y z) = cat <$> (cat <$> uvars level x <*> uvars level y) <*> uvars level z
-        puvars level (PFold z) = uvars level z
+        puvars level (PFold z)     = uvars level z
 
         cat :: [UVar] -> [UVar] -> [UVar]
         cat ts us = ts ++ filter (\u -> all (different u) ts) us
@@ -372,11 +372,11 @@ generalize e =
         buildFinal :: [String] -> [UVar] -> [(Pred, IORef (Maybe Evid))] -> Term -> Ty -> (Term, Ty)
         buildFinal names ts ps e t =
           (tyLams ts names (prLams ps e), quantifiers ts names (qualifiers ps t))
-          where quantifiers [] _ t = t
+          where quantifiers [] _ t              = t
                 quantifiers (u : us) (b : bs) t = TForall b (Just (uvKind u)) (quantifiers us bs t)
                 qualifiers [] t            = t
                 qualifiers ((p, _) : ps) t = TThen p (qualifiers ps t)
-                tyLams [] _ e = e
+                tyLams [] _ e              = e
                 tyLams (u : us) (b : bs) e = ETyLam b (Just (uvKind u)) (tyLams us bs e)
                 prLams [] e            = e
                 prLams ((p, _) : ps) e = EPrLam p (prLams ps e)

--- a/src/Checker/Types.hs
+++ b/src/Checker/Types.hs
@@ -1,18 +1,18 @@
 module Checker.Types where
 
-import Control.Monad
-import Control.Monad.Error.Class
-import Control.Monad.IO.Class
-import Control.Monad.Reader.Class
-import Control.Monad.Writer
-import Data.IORef
-import Data.List
+import           Control.Monad
+import           Control.Monad.Error.Class
+import           Control.Monad.IO.Class
+import           Control.Monad.Reader.Class
+import           Control.Monad.Writer
+import           Data.IORef
+import           Data.List
 
-import Checker.Monad hiding (collect, trace)
-import Checker.Normalize
-import Checker.Utils
-import Printer
-import Syntax
+import           Checker.Monad              hiding (collect, trace)
+import           Checker.Normalize
+import           Checker.Utils
+import           Printer
+import           Syntax
 
 trace :: MonadIO m => String -> m ()
 trace s = liftIO $
@@ -36,7 +36,7 @@ bindRef (Goal (s, r)) (Just k) =
           | otherwise = do k' <- readRef r'
                            case k' of
                              Just k'' -> check k''
-                             Nothing -> return True
+                             Nothing  -> return True
 
   -- Note: just returning a `Ty` here out of convenience; it's always an exactly the input `Ty`.
 expectK :: MonadCheck m => Ty -> Kind -> Kind -> m Ty
@@ -83,7 +83,7 @@ unifyK' (KRow rActual) kExpected = ((1+) <$>) <$> unifyK rActual kExpected
 unifyK' (KFun dActual cActual) (KFun dExpected cExpected) =
   (*&*) <$> unifyK dActual dExpected <*> unifyK cActual cExpected where
   Just 0 *&* Just 0 = Just 0
-  _ *&* _ = Nothing
+  _ *&* _           = Nothing
 unifyK' _ _ =
   return Nothing
 
@@ -261,7 +261,7 @@ checkTy0 t@(TPlus x y) expected =
                tell [(PPlus x' y' z, v)]
                return z
     where splitConcrete (TLabeled (TLab s) x) = Just (TLab s, x)
-          splitConcrete _ = Nothing
+          splitConcrete _                     = Nothing
 checkTy0 t@(TConOrd k rel u) expected =
   do u' <- checkTy u (KRow expected)
      z@(TUnif v) <- typeGoal' "z" (KRow expected)

--- a/src/Checker/Types.hs
+++ b/src/Checker/Types.hs
@@ -1,18 +1,18 @@
 module Checker.Types where
 
-import           Control.Monad
-import           Control.Monad.Error.Class
-import           Control.Monad.IO.Class
-import           Control.Monad.Reader.Class
-import           Control.Monad.Writer
-import           Data.IORef
-import           Data.List
+import Control.Monad
+import Control.Monad.Error.Class
+import Control.Monad.IO.Class
+import Control.Monad.Reader.Class
+import Control.Monad.Writer
+import Data.IORef
+import Data.List
 
-import           Checker.Monad              hiding (collect, trace)
-import           Checker.Normalize
-import           Checker.Utils
-import           Printer
-import           Syntax
+import Checker.Monad              hiding (collect, trace)
+import Checker.Normalize
+import Checker.Utils
+import Printer
+import Syntax
 
 trace :: MonadIO m => String -> m ()
 trace s = liftIO $
@@ -222,7 +222,7 @@ checkTy0 (TConApp (Mu count) f) expected = TConApp (Mu count) <$> checkTy f (KFu
 checkTy0 (TConApp (TCUnif g) t) expected =
   do mk <- readRef (goalRef g)
      case mk of
-       Just k -> checkTy0 (TConApp k t) expected
+       Just k  -> checkTy0 (TConApp k t) expected
        Nothing -> fail "don't know how to kind check unknown constructor application"
 checkTy0 (TInst ig t) expected =
   TInst ig <$> checkTy t expected

--- a/src/Checker/Unify.hs
+++ b/src/Checker/Unify.hs
@@ -1,25 +1,25 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Checker.Unify (module Checker.Unify) where
 
-import           Control.Monad
-import           Control.Monad.Except
-import           Control.Monad.Reader
-import           Control.Monad.State
-import           Control.Monad.Writer
-import           Data.Bifunctor       (first)
-import           Data.List            (elemIndex, partition, sortOn)
-import           Data.Maybe           (fromJust, isNothing)
+import Control.Monad
+import Control.Monad.Except
+import Control.Monad.Reader
+import Control.Monad.State
+import Control.Monad.Writer
+import Data.Bifunctor       (first)
+import Data.List            (elemIndex, partition, sortOn)
+import Data.Maybe           (fromJust, isNothing)
 
-import           Checker.Monad
-import           Checker.Normalize
-import           Checker.Promote
-import           Checker.Types        hiding (trace)
-import           Checker.Utils
-import           Printer
-import           Syntax
+import Checker.Monad
+import Checker.Normalize
+import Checker.Promote
+import Checker.Types        hiding (trace)
+import Checker.Utils
+import Printer
+import Syntax
 
-import qualified Debug.Trace          as T
-import           GHC.Stack
+import Debug.Trace          qualified as T
+import GHC.Stack
 
 {--
 
@@ -173,11 +173,11 @@ unifyInstantiating t u unify =
         match (Known is : is') qs =
           do (ms, qs') <- matchKnown is qs
              (ms ++) <$> match is' qs'
-          where matchKnown [] qs = return ([], qs)
+          where matchKnown [] qs                              = return ([], qs)
                 matchKnown (TyArg t : is) (QuForall _ k : qs) = (first (Left (Left (t, k)) :)) <$> matchKnown is qs
-                matchKnown (PrArg v : is) (QuThen p : qs) = first (Left (Right (v, p)) :) <$> matchKnown is qs
-                matchKnown _ [] = T.trace "3 ruh-roh" Nothing
-                matchKnown is qs = error $ "ruh-roh: " ++ show is ++ ", " ++ show qs
+                matchKnown (PrArg v : is) (QuThen p : qs)     = first (Left (Right (v, p)) :) <$> matchKnown is qs
+                matchKnown _ []                               = T.trace "3 ruh-roh" Nothing
+                matchKnown is qs                              = error $ "ruh-roh: " ++ show is ++ ", " ++ show qs
         match is qs =
           T.trace (unlines ["1 ruh-roh: in ", renderString (ppr t), " ~ ", renderString (ppr u), "misaligned " ++ show is ++ " and " ++ show qs])
           Nothing -- error $ unlines ["ruh-roh: in ", renderString (ppr t), " ~ ", renderString (ppr u), "misaligned " ++ show is ++ " and " ++ show qs]
@@ -425,5 +425,5 @@ unify0 t u
         refinable _          = False
 
 unifyP :: Pred -> Pred -> UnifyM Evid
-unifyP (PLeq y z) (PLeq y' z') = VEqLeq <$> unify' y y' <*> unify' z z'
+unifyP (PLeq y z) (PLeq y' z')        = VEqLeq <$> unify' y y' <*> unify' z z'
 unifyP (PPlus x y z) (PPlus x' y' z') = VEqPlus <$> unify' x x' <*> unify' y y' <*> unify' z z'

--- a/src/Checker/Unify.hs
+++ b/src/Checker/Unify.hs
@@ -1,25 +1,25 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Checker.Unify (module Checker.Unify) where
 
-import Control.Monad
-import Control.Monad.Except
-import Control.Monad.Reader
-import Control.Monad.State
-import Control.Monad.Writer
-import Data.Bifunctor (first)
-import Data.List (elemIndex, partition, sortOn)
-import Data.Maybe (fromJust, isNothing)
+import           Control.Monad
+import           Control.Monad.Except
+import           Control.Monad.Reader
+import           Control.Monad.State
+import           Control.Monad.Writer
+import           Data.Bifunctor       (first)
+import           Data.List            (elemIndex, partition, sortOn)
+import           Data.Maybe           (fromJust, isNothing)
 
-import Checker.Monad
-import Checker.Normalize
-import Checker.Promote
-import Checker.Types hiding (trace)
-import Checker.Utils
-import Printer
-import Syntax
+import           Checker.Monad
+import           Checker.Normalize
+import           Checker.Promote
+import           Checker.Types        hiding (trace)
+import           Checker.Utils
+import           Printer
+import           Syntax
 
-import GHC.Stack
-import qualified Debug.Trace as T
+import qualified Debug.Trace          as T
+import           GHC.Stack
 
 {--
 
@@ -219,7 +219,7 @@ unifyInstantiating t u unify =
 
         reverseIs :: Insts -> Insts
         reverseIs is@(Unknown {}) = is
-        reverseIs (Known is) = Known (reverse is)
+        reverseIs (Known is)      = Known (reverse is)
 
 unify0 :: HasCallStack => Ty -> Ty -> UnifyM Evid
 unify0 (TVar i _) (TVar j _)
@@ -352,9 +352,9 @@ unify0 (TConApp (Mu count) f) (TConApp (Mu count') g) =
   VEqCon (Mu count'') <$> unify' f g where
     count'' = case (count, count') of
                 (Nothing, Nothing) -> Nothing
-                (Nothing, Just n) -> Just n
-                (Just m, Nothing) -> Just m
-                (Just m, Just n) -> Just (min m n)
+                (Nothing, Just n)  -> Just n
+                (Just m, Nothing)  -> Just m
+                (Just m, Just n)   -> Just (min m n)
 unify0 t u
   | (TConApp (Mu count) f, ts) <- spine t, noHeadUnif u, Just count' <- decr count =
     unify' (foldl TApp f (TConApp (Mu count') f : ts)) u
@@ -365,7 +365,7 @@ unify0 t u
           | otherwise = True
         decr (Just 0) = Nothing
         decr (Just n) = Just (Just (n - 1))
-        decr Nothing = Just (Just 20)
+        decr Nothing  = Just (Just 20)
 unify0 t0@(TConApp (TCUnif g) t) u =
   do mk <- readRef (goalRef g)
      case mk of

--- a/src/Checker/Utils.hs
+++ b/src/Checker/Utils.hs
@@ -1,9 +1,9 @@
 module Checker.Utils where
 
-import           Control.Monad.Reader.Class
+import Control.Monad.Reader.Class
 
-import           Checker.Monad
-import           Syntax
+import Checker.Monad
+import Syntax
 
 kindGoal :: MonadCheck m => String -> m Kind
 kindGoal s =

--- a/src/Checker/Utils.hs
+++ b/src/Checker/Utils.hs
@@ -1,9 +1,9 @@
 module Checker.Utils where
 
-import Control.Monad.Reader.Class
+import           Control.Monad.Reader.Class
 
-import Checker.Monad
-import Syntax
+import           Checker.Monad
+import           Syntax
 
 kindGoal :: MonadCheck m => String -> m Kind
 kindGoal s =
@@ -24,7 +24,7 @@ kindOf t@(TApp f _) =
   do k' <- kindOf f
      case k' of
        KFun _ k -> return k
-       _ -> fail ("kindOf: ill-kinded " ++ show t)
+       _        -> fail ("kindOf: ill-kinded " ++ show t)
 kindOf (TLab _) = return KLabel
 kindOf (TSing _) = return KType
 kindOf (TLabeled _ t) = kindOf t

--- a/src/Interp/Erased.hs
+++ b/src/Interp/Erased.hs
@@ -1,15 +1,15 @@
 module Interp.Erased where
 
-import           Control.Monad.Reader
-import           Data.IORef
-import           Data.List            (elemIndex, intercalate, sortOn)
-import           Data.Maybe           (fromMaybe, isJust)
-import qualified Debug.Trace          as T
-import           Foreign              (toBool)
-import           GHC.Stack
-import           Printer
-import           Syntax
-import           System.IO.Unsafe
+import Control.Monad.Reader
+import Data.IORef
+import Data.List            (elemIndex, intercalate, sortOn)
+import Data.Maybe           (fromMaybe, isJust)
+import Debug.Trace          qualified as T
+import Foreign              (toBool)
+import GHC.Stack
+import Printer
+import Syntax
+import System.IO.Unsafe
 
 traceEvaluation :: IORef Bool
 traceEvaluation = unsafePerformIO (newIORef False)
@@ -49,9 +49,9 @@ fromBool True  = VVariant 1 vUnit (Just "True")
 
 instance FromPeano Value where
   fromPeano :: Value -> Maybe Int
-  fromPeano (VVariant _ p (Just "Succ")) = fmap (+ 1) (fromPeano p)
+  fromPeano (VVariant _ p (Just "Succ"))               = fmap (+ 1) (fromPeano p)
   fromPeano (VVariant _ (VRecord [] []) (Just "Zero")) = Just 0
-  fromPeano _ = Nothing
+  fromPeano _                                          = Nothing
 
 listFromVariant :: Value -> Maybe [String]
 -- Match on names = ["1", "2"]
@@ -112,7 +112,7 @@ evalB h (Prim f) = f h
 
 app :: Value -> Value -> Value
 app (VLam (hp, he) f') v = evalB (hp, v : he) f'
-app v w = error $ "don't know how to apply " ++ show v ++ " to " ++ show w
+app v w                  = error $ "don't know how to apply " ++ show v ++ " to " ++ show w
 
 prapp :: Value -> EValue -> Value
 prapp f@(VPrLam (hp, he) f') v =

--- a/src/Interp/Naive.hs
+++ b/src/Interp/Naive.hs
@@ -1,16 +1,16 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Interp.Naive where
 
-import Control.Monad.Reader (runReaderT)
-import Data.IORef
-import qualified Prettyprinter as P
-import System.IO.Unsafe (unsafePerformIO)
-import Printer
-import Syntax
+import           Control.Monad.Reader (runReaderT)
+import           Data.IORef
+import qualified Prettyprinter        as P
+import           Printer
+import           Syntax
+import           System.IO.Unsafe     (unsafePerformIO)
 
-import GHC.Stack
+import           GHC.Stack
 
-import qualified Debug.Trace as T
+import qualified Debug.Trace          as T
 {-# NOINLINE traceEvaluation #-}
 
 traceEvaluation :: IORef Bool
@@ -29,16 +29,16 @@ data Value = VTyLam Env String Kind Term | VPrLam Env Pred Term | VLam Env Strin
            | VAna Ty Value | VSyn Ty Value
 
 instance Show Value where
-  show (VTyLam {}) = "VTyLam"
-  show (VPrLam {}) = "VPrLam"
-  show (VLam {}) = "VLam"
-  show (VIn {}) = "VIn"
-  show (VSing t) = "VSing"
+  show (VTyLam {})    = "VTyLam"
+  show (VPrLam {})    = "VPrLam"
+  show (VLam {})      = "VLam"
+  show (VIn {})       = "VIn"
+  show (VSing t)      = "VSing"
   show (VLabeled s v) = "VLabeled"
-  show (VRecord {}) = "VRecord"
-  show (VBranch {}) = "VBranch"
-  show (VAna _ e) = "VAna (" ++ show e ++ ")"
-  show (VSyn _ e) = "VSyn (" ++ show e ++ ")"
+  show (VRecord {})   = "VRecord"
+  show (VBranch {})   = "VBranch"
+  show (VAna _ e)     = "VAna (" ++ show e ++ ")"
+  show (VSyn _ e)     = "VSyn (" ++ show e ++ ")"
 
 -- prededence:
 -- lambda   0
@@ -99,17 +99,17 @@ eval' h e0@(EApp (EInst (EConst CPrj) (Known [TyArg y, TyArg z, _])) e)   -- rem
     ls = dom e0 (substTy h y)
     prj (VRecord fs) = VRecord [(l, th) | (l, th) <- fs, l `elem` ls]
     prj v@VLabeled{} = v  -- can do dumb projections
-    prj v@VSyn{} = v   -- synthesizing fewer fields is the same as synthesizing more fields
+    prj v@VSyn{}     = v   -- synthesizing fewer fields is the same as synthesizing more fields
     -- alternatively, we could do the computation here:
     -- prj (VSyn _ m) = VRecord [(l, app (eval h m) (VSing (TLab l))) | l <- ls]
 eval' h e@(EApp (EInst (EApp (EInst (EConst CConcat) (Known [TyArg x, TyArg y, _, _])) m) (Known [])) n) =
   VRecord (fields xls (eval h m) ++ fields yls (eval h n)) where
   xls = dom e (substTy h x)
   yls = dom e (substTy h y)
-  fields _ (VRecord fs) = fs
+  fields _ (VRecord fs)    = fs
   fields _ (VLabeled s th) = [(s, th)]
-  fields ls (VSyn _ m) = [(l, app h m (VSing (TLab l))) | l <- ls]
-  fields _ _ = error $ "evaluation failed: " ++ show e
+  fields ls (VSyn _ m)     = [(l, app h m (VSing (TLab l))) | l <- ls]
+  fields _ _               = error $ "evaluation failed: " ++ show e
 eval' h (EApp (EInst (EConst CInj) (Known [TyArg y, TyArg z, _])) e) = eval h e
 eval' h e@(EApp (EInst (EApp (EInst (EConst CBranch) (Known [TyArg x, TyArg y, _, _, _])) f) (Known [])) g) = VBranch (dom e (substTy h x)) (eval h f) (eval h g)
 eval' h (EApp (EInst (EConst CIn) _) e) = VIn (eval h e) -- also treating in like a constructor... probably will need that functor evidence eventually, but meh

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -3,29 +3,28 @@
 {-# OPTIONS_GHC -Wno-overlapping-patterns #-}
 module Main where
 
-import           Control.Monad         (void, when, (<=<))
-import           Control.Monad.Reader  (runReaderT)
-import           Control.Monad.State
-import           Data.IORef
-import           Data.List             (break, findIndex)
-import           Data.List.Split
-import           Data.String
-import qualified Prettyprinter         as P
-import qualified Prettyprinter.Util    as P
-import           System.Console.GetOpt
-import           System.Directory
-import           System.Environment
-import           System.Exit           (exitFailure)
-import           System.FilePath
-import           System.IO             (BufferMode (..), hPutStrLn,
-                                        hSetBuffering, stderr, stdout)
+import Control.Monad         (void, when, (<=<))
+import Control.Monad.Reader  (runReaderT)
+import Control.Monad.State
+import Data.IORef
+import Data.List             (break, findIndex)
+import Data.List.Split
+import Data.String
+import Prettyprinter         qualified as P
+import Prettyprinter.Util    qualified as P
+import System.Console.GetOpt
+import System.Directory
+import System.Environment
+import System.Exit           (exitFailure)
+import System.FilePath
+import System.IO             (BufferMode (..), hPutStrLn, hSetBuffering, stderr, stdout)
 
-import           Checker
-import           Interp.Erased         as E
-import           Parser
-import           Printer
-import           Scope
-import           Syntax
+import Checker
+import Interp.Erased         as E
+import Parser
+import Printer
+import Scope
+import Syntax
 
 data Flags = Flags { evals :: [String], inputs :: [String], imports :: [String]
                    , doTraceKindInference, doTraceInference

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,29 +1,31 @@
-{-# LANGUAGE OverloadedStrings, TupleSections #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections     #-}
 {-# OPTIONS_GHC -Wno-overlapping-patterns #-}
 module Main where
 
-import Control.Monad ((<=<), void, when)
-import Control.Monad.Reader (runReaderT)
-import Control.Monad.State
-import Data.IORef
-import Data.List (findIndex, break)
-import Data.List.Split
-import Data.String
-import qualified Prettyprinter as P
-import qualified Prettyprinter.Util as P
-import System.Console.GetOpt
-import System.Exit (exitFailure)
-import System.Directory
-import System.Environment
-import System.FilePath
-import System.IO (hPutStrLn, stderr, stdout, hSetBuffering, BufferMode(..))
+import           Control.Monad         (void, when, (<=<))
+import           Control.Monad.Reader  (runReaderT)
+import           Control.Monad.State
+import           Data.IORef
+import           Data.List             (break, findIndex)
+import           Data.List.Split
+import           Data.String
+import qualified Prettyprinter         as P
+import qualified Prettyprinter.Util    as P
+import           System.Console.GetOpt
+import           System.Directory
+import           System.Environment
+import           System.Exit           (exitFailure)
+import           System.FilePath
+import           System.IO             (BufferMode (..), hPutStrLn,
+                                        hSetBuffering, stderr, stdout)
 
-import Checker
-import Interp.Erased as E
-import Parser
-import Printer
-import Scope
-import Syntax
+import           Checker
+import           Interp.Erased         as E
+import           Parser
+import           Printer
+import           Scope
+import           Syntax
 
 data Flags = Flags { evals :: [String], inputs :: [String], imports :: [String]
                    , doTraceKindInference, doTraceInference

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -1,31 +1,30 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 module Parser where
 
-import           Syntax
+import Syntax
 
-import           Control.Monad              (foldM, guard, mplus, replicateM,
-                                             void, when)
+import Control.Monad              (foldM, guard, mplus, replicateM, void, when)
 -- import Control.Monad.IO.Class (liftIO)
-import           Control.Monad.Reader
-import           Control.Monad.State
+import Control.Monad.Reader
+import Control.Monad.State
 
-import           Data.Char                  (isSpace)
-import           Data.Data
-import           Data.IORef                 (newIORef)
-import           Data.List                  (delete, intercalate)
-import           Data.List.NonEmpty         (fromList)
-import           Data.List.Split            (splitOn)
-import           Data.Maybe                 (fromMaybe, isNothing)
-import           Data.Void                  (Void)
-import           System.Exit                (exitFailure)
-import           System.IO                  (hPutStrLn, stderr)
+import Data.Char                  (isSpace)
+import Data.Data
+import Data.IORef                 (newIORef)
+import Data.List                  (delete, intercalate)
+import Data.List.NonEmpty         (fromList)
+import Data.List.Split            (splitOn)
+import Data.Maybe                 (fromMaybe, isNothing)
+import Data.Void                  (Void)
+import System.Exit                (exitFailure)
+import System.IO                  (hPutStrLn, stderr)
 
-import           Text.Megaparsec            hiding (State)
-import           Text.Megaparsec.Char
-import qualified Text.Megaparsec.Char.Lexer as P
-import           Text.Megaparsec.Error
+import Text.Megaparsec            hiding (State)
+import Text.Megaparsec.Char
+import Text.Megaparsec.Char.Lexer qualified as P
+import Text.Megaparsec.Error
 
-import           Debug.Trace
+import Debug.Trace
 
 --------------------------------------------------------------------------------
 -- Combinators I miss from Parsec
@@ -447,9 +446,9 @@ appTerm = do (t : ts) <- some (Type <$> brackets ty <|> Term <$> aterm)
                  , do symbol "("
                       t <- do ts <- commaSep1 term
                               case (ts, mapM labeledTerm ts) of
-                                 ([t], _) -> return t
+                                 ([t], _)           -> return t
                                  (_, Just (t : ts)) -> return (foldl (\t1 t2 -> EApp (EApp (EConst CConcat) t1) t2) t ts)
-                                 (_, Nothing) -> unexpected $ Label (fromList "unlabeled term")
+                                 (_, Nothing)       -> unexpected $ Label (fromList "unlabeled term")
                       guardIndent (string ")")
                       s <- optional stor
                       whitespace

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -1,30 +1,31 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 module Parser where
 
-import Syntax
+import           Syntax
 
-import Control.Monad (foldM, guard, mplus, replicateM, void, when)
+import           Control.Monad              (foldM, guard, mplus, replicateM,
+                                             void, when)
 -- import Control.Monad.IO.Class (liftIO)
-import Control.Monad.Reader
-import Control.Monad.State
+import           Control.Monad.Reader
+import           Control.Monad.State
 
-import Data.Char (isSpace)
-import Data.Data
-import Data.IORef (newIORef)
-import Data.List (delete, intercalate)
-import Data.List.NonEmpty (fromList)
-import Data.List.Split (splitOn)
-import Data.Maybe (fromMaybe, isNothing)
-import Data.Void (Void)
-import System.IO (hPutStrLn, stderr)
-import System.Exit (exitFailure)
+import           Data.Char                  (isSpace)
+import           Data.Data
+import           Data.IORef                 (newIORef)
+import           Data.List                  (delete, intercalate)
+import           Data.List.NonEmpty         (fromList)
+import           Data.List.Split            (splitOn)
+import           Data.Maybe                 (fromMaybe, isNothing)
+import           Data.Void                  (Void)
+import           System.Exit                (exitFailure)
+import           System.IO                  (hPutStrLn, stderr)
 
-import Text.Megaparsec hiding (State)
-import Text.Megaparsec.Char
+import           Text.Megaparsec            hiding (State)
+import           Text.Megaparsec.Char
 import qualified Text.Megaparsec.Char.Lexer as P
-import Text.Megaparsec.Error
+import           Text.Megaparsec.Error
 
-import Debug.Trace
+import           Debug.Trace
 
 --------------------------------------------------------------------------------
 -- Combinators I miss from Parsec
@@ -38,7 +39,7 @@ chainr1 p op =
                       rhs <- p
                       return (f, rhs))
      return (down lhs rhss)
-  where down lhs [] = lhs
+  where down lhs []                 = lhs
         down lhs ((op, rhs) : rhss) = op lhs (down rhs rhss)
 
 chainl1 :: Parser a -> Parser (a -> a -> a) -> Parser a
@@ -48,7 +49,7 @@ chainl1 p op =
                       rhs <- p
                       return (f, rhs))
      return (down lhs rhss)
-  where down lhs [] = lhs
+  where down lhs []                 = lhs
         down lhs ((op, rhs) : rhss) = down (op lhs rhs) rhss
 
 ps :: Show t => Parser t -> String -> IO ()
@@ -68,7 +69,7 @@ theIndent :: Parser (Maybe (Ordering, Pos))
 theIndent =
   do is <- lift get
      case is of
-       [] -> return Nothing
+       []    -> return Nothing
        i : _ -> return (Just i)
 
 guardIndent :: Parser a -> Parser a
@@ -236,7 +237,7 @@ labeledTy =
   do t <- labTy
      case t of
        TLabeled _ _ -> return t
-       _ -> unexpected (Label $ fromList "unlabeled type")
+       _            -> unexpected (Label $ fromList "unlabeled type")
 
 
 tcon = choice [ ordered (string "Pi") Pi
@@ -332,7 +333,7 @@ term = prefixes typedTerm where
     do mp <- optional (try prefix)
        case mp of
          Nothing -> rest
-         Just f -> f <$> prefixes rest
+         Just f  -> f <$> prefixes rest
 
   op :: String -> Parser a -> Parser a
   op s k = symbol s >> k
@@ -390,7 +391,7 @@ term = prefixes typedTerm where
          , return t ]
 
     -- chainl1 catTerm $ choice [op ":=" (return ELabel), op "/" (return EUnlabel)]
- 
+
   stringEqTerm = chainl1 catTerm $ op "~" (ebinary CStringEq)
 
   catTerm = chainl1 appTerm $ op "^" (ebinary CStringCat)
@@ -402,8 +403,8 @@ appTerm = do (t : ts) <- some (Type <$> brackets ty <|> Term <$> aterm)
              app t ts where
 
   app :: AppTerm -> [AppTerm] -> Parser Term
-  app (Term t) [] = return t
-  app (Type _) _ = unexpected (Label $ fromList "type argument")
+  app (Term t) []            = return t
+  app (Type _) _             = unexpected (Label $ fromList "type argument")
   app (Term t) (Term u : ts) = app (Term (EApp t u)) ts
   app (Term t) (Type u : ts) = app (Term (EInst t (Known [TyArg u]))) ts
 

--- a/src/Printer.hs
+++ b/src/Printer.hs
@@ -3,16 +3,16 @@
 {-# HLINT ignore "Eta reduce" #-}
 module Printer where
 
-import Control.Monad.Reader
-import Data.IORef (readIORef)
-import Data.List (intercalate)
-import Data.String
-import qualified Prettyprinter as P
+import           Control.Monad.Reader
+import           Data.IORef                  (readIORef)
+import           Data.List                   (intercalate)
+import           Data.String
+import qualified Prettyprinter               as P
 import qualified Prettyprinter.Render.String as P
-import qualified Prettyprinter.Util as P
-import System.IO.Unsafe
+import qualified Prettyprinter.Util          as P
+import           System.IO.Unsafe
 
-import Syntax
+import           Syntax
 
 data PrinterOptions = PO { level :: Int, printKinds :: Bool, printMaps :: Bool, printInstantiations :: Bool }
 type RDoc ann = ReaderT PrinterOptions IO (P.Doc ann)
@@ -76,9 +76,9 @@ brackets = fmap P.brackets
 parens = fmap P.parens
 
 stringFromQName :: QName -> String
-stringFromQName [x] = x
+stringFromQName [x]     = x
 stringFromQName [x, ""] = x
-stringFromQName xs = intercalate "." (reverse xs)
+stringFromQName xs      = intercalate "." (reverse xs)
 
 instance Printable QName where
   ppr = ppre . stringFromQName
@@ -129,7 +129,7 @@ instance Printable TyCon where
   ppr (TCUnif g) =
     do mk <- liftIO (readIORef (goalRef g))
        case mk of
-         Just k -> ppr k
+         Just k  -> ppr k
          Nothing -> ppre (goalName g)
 
 getTupleContents :: [Ty] -> Int -> Maybe [Ty]
@@ -207,10 +207,10 @@ instance Printable Ty where
 
 instance Printable Pred where
   ppr :: Pred -> RDoc ann
-  ppr (PLeq t u) = fillSep [ppr t <+> "<", ppr u ]
+  ppr (PLeq t u)    = fillSep [ppr t <+> "<", ppr u ]
   ppr (PPlus t u v) = fillSep [ppr t <+> "+", ppr u <+> "~", ppr v]
-  ppr (PEq t u) = fillSep [ppr t <+> "~", ppr u]
-  ppr (PFold z) = fillSep ["Fold", ppr z]
+  ppr (PEq t u)     = fillSep [ppr t <+> "~", ppr u]
+  ppr (PFold z)     = fillSep ["Fold", ppr z]
 
 -- Precedence table:
 --   lambda           0
@@ -223,9 +223,9 @@ class FromPeano a where
 
 instance FromPeano Term where
   fromPeano :: Term -> Maybe Int
-  fromPeano (EVar _ ["zero","Nat","Data"]) = Just 0
+  fromPeano (EVar _ ["zero","Nat","Data"])          = Just 0
   fromPeano (EApp (EVar _ ["succ","Nat","Data"]) p) = fmap (+ 1) (fromPeano p)
-  fromPeano _ = Nothing
+  fromPeano _                                       = Nothing
 
 instance Printable Term where
   ppr (EVar _ s) = ppr s
@@ -257,16 +257,16 @@ instance Printable Term where
   ppr (EUnlabel Nothing m l) = with 3 (fillSep [ppr m <+> "/", at 3 (ppr l)])
   ppr (EUnlabel (Just k) m l) = with 3 (fillSep [ppr m <+> "/" <> ppr k, at 3 (ppr l)])
   ppr (EConst c) = name c where
-    name CPrj = "prj"
-    name CConcat = "(++)"
-    name CInj = "inj"
-    name CBranch = "(|)"
-    name CFix = "fix"
+    name CPrj       = "prj"
+    name CConcat    = "(++)"
+    name CInj       = "inj"
+    name CBranch    = "(|)"
+    name CFix       = "fix"
     name CStringCat = "(^)"
-    name CStringEq = "(~)"
-    name CSyn = "syn"
-    name CAna = "ana"
-    name CFold = "fold"
+    name CStringEq  = "(~)"
+    name CSyn       = "syn"
+    name CAna       = "ana"
+    name CFold      = "fold"
   ppr (ELet x m n) = with 0 $ nest 2 $ fillSep ["let" <+> ppre x <+> "=" <+> ppr m <+> "in", ppr n]
   ppr (ETyped e t) = with 1 (fillSep [ppr e <+> ":", ppr t])
   -- Not printing internals (yet)

--- a/src/Printer.hs
+++ b/src/Printer.hs
@@ -3,16 +3,16 @@
 {-# HLINT ignore "Eta reduce" #-}
 module Printer where
 
-import           Control.Monad.Reader
-import           Data.IORef                  (readIORef)
-import           Data.List                   (intercalate)
-import           Data.String
-import qualified Prettyprinter               as P
-import qualified Prettyprinter.Render.String as P
-import qualified Prettyprinter.Util          as P
-import           System.IO.Unsafe
+import Control.Monad.Reader
+import Data.IORef                  (readIORef)
+import Data.List                   (intercalate)
+import Data.String
+import Prettyprinter               qualified as P
+import Prettyprinter.Render.String qualified as P
+import Prettyprinter.Util          qualified as P
+import System.IO.Unsafe
 
-import           Syntax
+import Syntax
 
 data PrinterOptions = PO { level :: Int, printKinds :: Bool, printMaps :: Bool, printInstantiations :: Bool }
 type RDoc ann = ReaderT PrinterOptions IO (P.Doc ann)
@@ -188,7 +188,7 @@ instance Printable Ty where
        then do minst <- liftIO $ readIORef r
                case minst of
                  Nothing -> brackets ("^" <> ppre n <> "%" <> ppre s) <+> parens (ppr t)
-                 Just is  -> ppr (TInst is t)
+                 Just is -> ppr (TInst is t)
        else ppr t
   ppr (TInst (Known is) t) =
     do b <- asks printInstantiations
@@ -288,13 +288,13 @@ pprTyping (x, ty, e) =
 pprTypeError :: Error -> RDoc ann
 pprTypeError te = vsep ctxts <> pure P.line <> indent 2 (pprErr te')
   where d <:> (ds, te) = (d : ds, te)
-        contexts (ErrContextDefn d te) = ("Whilst checking the definition of" <+> ppr d) <:> contexts te
-        contexts (ErrContextType ty te) = ("Whilst checking the type" <+> ppr ty) <:> contexts te
-        contexts (ErrContextPred pr te) = ("Whilst checking the predicate" <+> ppr pr) <:> contexts te
-        contexts (ErrContextTerm t te) = ("While checking the term" <+> ppr t) <:> contexts te
+        contexts (ErrContextDefn d te)   = ("Whilst checking the definition of" <+> ppr d) <:> contexts te
+        contexts (ErrContextType ty te)  = ("Whilst checking the type" <+> ppr ty) <:> contexts te
+        contexts (ErrContextPred pr te)  = ("Whilst checking the predicate" <+> ppr pr) <:> contexts te
+        contexts (ErrContextTerm t te)   = ("While checking the term" <+> ppr t) <:> contexts te
         contexts (ErrContextTyEq t u te) = ("While comparing the types" <+> ppr t <+> "and" <+> ppr u) <:> contexts te
-        contexts (ErrContextOther s te) = ppre s <:> contexts te
-        contexts te = ([], te)
+        contexts (ErrContextOther s te)  = ppre s <:> contexts te
+        contexts te                      = ([], te)
 
         (ctxts, te') = contexts te
 

--- a/src/Scope.hs
+++ b/src/Scope.hs
@@ -1,12 +1,12 @@
 module Scope where
 
-import           Control.Monad.Except
-import           Control.Monad.Reader
-import           Control.Monad.State
-import           Data.Bifunctor
-import           Data.List
-import           Data.Maybe
-import           Syntax
+import Control.Monad.Except
+import Control.Monad.Reader
+import Control.Monad.State
+import Data.Bifunctor
+import Data.List
+import Data.Maybe
+import Syntax
 
 newtype ScopeM a = ScopeM { runScope :: ReaderT ([QName], [QName]) (Except Error) a }
   deriving (Functor, Applicative, Monad, MonadReader ([QName], [QName]), MonadError Error)
@@ -177,7 +177,7 @@ declName (TmDecl x _ _) = x
 declName (TyDecl x _ _) = x
 
 scopeProg :: [Decl] -> ScopeM [Decl]
-scopeProg [] = return []
+scopeProg []                      = return []
 scopeProg (d@(TmDecl x _ _) : ds) = (:) <$> scope d <*> bindGVar x (scopeProg ds)
 scopeProg (d@(TyDecl x _ _) : ds) = (:) <$> scope d <*> bindGTyVar x (scopeProg ds)
 

--- a/src/Scope.hs
+++ b/src/Scope.hs
@@ -1,12 +1,12 @@
 module Scope where
 
-import Control.Monad.Except
-import Control.Monad.Reader
-import Control.Monad.State
-import Data.Bifunctor
-import Data.List
-import Data.Maybe
-import Syntax
+import           Control.Monad.Except
+import           Control.Monad.Reader
+import           Control.Monad.State
+import           Data.Bifunctor
+import           Data.List
+import           Data.Maybe
+import           Syntax
 
 newtype ScopeM a = ScopeM { runScope :: ReaderT ([QName], [QName]) (Except Error) a }
   deriving (Functor, Applicative, Monad, MonadReader ([QName], [QName]), MonadError Error)
@@ -81,10 +81,10 @@ bindableTyVars (TPlus t u) = bindableTyVars t >> bindableTyVars u
 bindableTyVars (TConOrd _ _ t) = bindableTyVars t
 bindableTyVars t = error $ "<whoopsie: " ++ show t ++ ">"
 
-bindableTyVarsP (PEq t u) = bindableTyVars t >> bindableTyVars u
-bindableTyVarsP (PLeq y z) = bindableTyVars y >> bindableTyVars z
+bindableTyVarsP (PEq t u)     = bindableTyVars t >> bindableTyVars u
+bindableTyVarsP (PLeq y z)    = bindableTyVars y >> bindableTyVars z
 bindableTyVarsP (PPlus x y z) = mapM_ bindableTyVars [x, y, z]
-bindableTyVarsP (PFold z) = bindableTyVars z
+bindableTyVarsP (PFold z)     = bindableTyVars z
 
 bindable :: [Name] -> Ty -> [Name]
 bindable vs t = take (length ws - length vs) ws
@@ -133,10 +133,10 @@ implicitQuantifiers t =
      return (rebind (bs ++ [(x, Nothing) | x <- xs]) t'')
 
 instance HasVars Pred where
-  scope (PLeq y z) = PLeq <$> scope y <*> scope z
+  scope (PLeq y z)    = PLeq <$> scope y <*> scope z
   scope (PPlus x y z) = PPlus <$> scope x <*> scope y <*> scope z
-  scope (PEq t u) = PEq <$> scope t <*> scope u
-  scope (PFold z) = PFold <$> scope z
+  scope (PEq t u)     = PEq <$> scope t <*> scope u
+  scope (PFold z)     = PFold <$> scope z
 
 -- There's no `instance HasVars Evid` because evidence is all constructed during
 -- type checking, and so starts with de Bruijn indices.

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE PatternGuards #-}
 module Syntax (module Syntax) where
 
-import Control.Monad.IO.Class
-import Data.Bifunctor (first)
-import Data.Generics hiding (TyCon(..), GT)
-import Data.IORef
-import GHC.Stack
+import           Control.Monad.IO.Class
+import           Data.Bifunctor         (first)
+import           Data.Generics          hiding (GT, TyCon (..))
+import           Data.IORef
+import           GHC.Stack
 
 --------------------------------------------------------------------------------
 -- Top-level entities
@@ -74,29 +74,29 @@ data Level = Top | Lv Int
   deriving (Eq, Data, Typeable)
 
 instance Ord Level where
-  compare Top Top = EQ
-  compare Top _   = GT
-  compare _ Top   = LT
+  compare Top Top       = EQ
+  compare Top _         = GT
+  compare _ Top         = LT
   compare (Lv i) (Lv j) = compare i j
 
 tops :: (Int -> Int -> Int) -> Level -> Level -> Level
-tops f Top x = Top
-tops f x Top = Top
+tops f Top x         = Top
+tops f x Top         = Top
 tops f (Lv i) (Lv j) = Lv (f i j)
 
 instance Num Level where
   (+) = tops (+)
   (*) = tops (*)
-  abs Top = Top
+  abs Top    = Top
   abs (Lv i) = Lv i
-  signum Top = Lv 1
+  signum Top    = Lv 1
   signum (Lv x) = Lv (signum x)
   fromInteger = Lv . fromInteger
-  negate Top = Top
+  negate Top    = Top
   negate (Lv i) = Lv (negate i)
 
 instance Show Level where
-  show Top = "T"
+  show Top    = "T"
   show (Lv i) = show i
 
 data UVar = UV { uvShift :: Int, uvLevel :: Level, uvGoal :: Goal Ty, uvKind :: Kind }
@@ -161,17 +161,17 @@ tvFreeIn ns (TCompl t u) = tvFreeIn ns t || tvFreeIn ns u
 tvFreeIn ns TString = False
 tvFreeIn ns (TInst is t) = tvFreeInIs is || tvFreeIn ns t where
   tvFreeInIs (Unknown {}) = False
-  tvFreeInIs (Known is) = any tvFreeInI is
-  tvFreeInI (TyArg t) = tvFreeIn ns t
+  tvFreeInIs (Known is)   = any tvFreeInI is
+  tvFreeInI (TyArg t)  = tvFreeIn ns t
   tvFreeInI (PrArg {}) = False
 tvFreeIn ns (TMapApp t) = tvFreeIn ns t
 tvFreeIn ns (TPlus y z) = tvFreeIn ns y || tvFreeIn ns z
 tvFreeIn ns (TConOrd _ _ t) = tvFreeIn ns t
 
-tvFreeInP ns (PEq t u) = tvFreeIn ns t || tvFreeIn ns u
-tvFreeInP ns (PLeq y z) = tvFreeIn ns y || tvFreeIn ns z
+tvFreeInP ns (PEq t u)     = tvFreeIn ns t || tvFreeIn ns u
+tvFreeInP ns (PLeq y z)    = tvFreeIn ns y || tvFreeIn ns z
 tvFreeInP ns (PPlus x y z) = tvFreeIn ns x || tvFreeIn ns y || tvFreeIn ns z
-tvFreeInP ns (PFold z) = tvFreeIn ns z
+tvFreeInP ns (PFold z)     = tvFreeIn ns z
 
 
 
@@ -180,13 +180,13 @@ label, labeled :: Ty -> Maybe Ty
 concreteLabel :: Ty -> Maybe String
 
 label (TLabeled l _) = Just l
-label _ = Nothing
+label _              = Nothing
 
 concreteLabel (TLabeled (TLab s) _) = Just s
 concreteLabel _                     = Nothing
 
 labeled (TLabeled _ t) = Just t
-labeled _ = Nothing
+labeled _              = Nothing
 
 splitLabel :: Ty -> Maybe (Ty, Ty)
 splitLabel (TLabeled l t) = Just (l, t)
@@ -209,18 +209,18 @@ data Quant = QuForall String Kind | QuThen Pred
 
 quants :: Ty -> ([Quant], Ty)
 quants (TForall x (Just k) t) = first (QuForall x k :) (quants t)
-quants (TForall x Nothing t) = error "quants: forall without kind"
-quants (TThen p t) = first (QuThen p :) (quants t)
-quants t = ([], t)
+quants (TForall x Nothing t)  = error "quants: forall without kind"
+quants (TThen p t)            = first (QuThen p :) (quants t)
+quants t                      = ([], t)
 
 quantify :: [Quant] -> Ty -> Ty
-quantify [] t = t
+quantify [] t                   = t
 quantify (QuForall x k : qus) t = TForall x (Just k) (quantify qus t)
-quantify (QuThen p : qus) t = TThen p (quantify qus t)
+quantify (QuThen p : qus) t     = TThen p (quantify qus t)
 
 insts :: Ty -> ([Insts], Ty)
 insts (TInst is t) = first (is :) (insts t)
-insts t = ([], t)
+insts t            = ([], t)
 
 spine :: Ty -> (Ty, [Ty])
 spine (TApp f t) = (f', ts ++ [t])
@@ -389,7 +389,7 @@ flattenE :: MonadIO m => Term -> m Term
 flattenE = everywhereM (mkM flattenInsts) <=< everywhereM (mkM flattenT) <=< everywhereM (mkM flattenP) <=< everywhereM (mkM flattenK) <=< everywhereM (mkM flattenV) <=< everywhereM (mkM flattenTC) where
   (f <=< g) x = g x >>= f
   flattenInsts (EInst m is) = EInst m <$> flattenIs is
-  flattenInsts m = return m
+  flattenInsts m            = return m
 
 hasHoles :: Term -> Bool
 hasHoles (EHole {})       = True
@@ -465,9 +465,9 @@ data Evid =
   deriving (Data, Eq, Show, Typeable)
 
 isRefl :: Evid -> Bool
-isRefl VEqRefl = True
+isRefl VEqRefl  = True
 isRefl VLeqRefl = True
-isRefl v = False
+isRefl v        = False
 
 foldUnary :: (Evid -> Evid) -> Evid -> Evid
 foldUnary k q
@@ -490,7 +490,7 @@ flattenV (VPredEq v1 v2) =
      v2' <- flattenV v2
      return $ case v1' of
        VEqRefl -> v2'
-       _     -> VPredEq v1' v2'
+       _       -> VPredEq v1' v2'
 flattenV VLeqRefl = return VLeqRefl
 flattenV VEqRefl = return VEqRefl
 flattenV (VLeqTrans v1 v2) =
@@ -499,14 +499,14 @@ flattenV (VLeqTrans v1 v2) =
      return $ case (v1', v2') of
        (VLeqRefl, _) -> v2'
        (_, VLeqRefl) -> v1'
-       _          -> VLeqTrans v1' v2'
+       _             -> VLeqTrans v1' v2'
 flattenV (VEqTrans v1 v2) =
   do v1' <- flattenV v1
      v2' <- flattenV v2
      return $ case (v1', v2') of
        (VEqRefl, _) -> v2'
        (_, VEqRefl) -> v1'
-       _          -> VEqTrans v1' v2'
+       _            -> VEqTrans v1' v2'
 flattenV (VLeqLiftL t v) = foldUnary (VLeqLiftL t) <$> flattenV v
 flattenV (VLeqLiftR v t) = foldUnary (`VLeqLiftR` t) <$> flattenV v
 flattenV (VPlusLeqL v) = VPlusLeqL <$> flattenV v
@@ -517,7 +517,7 @@ flattenV (VEqSym v) = foldUnary VEqSym <$> flattenV v
 flattenV v@(VEqRowPermute is)
   | countUp is 0 = return VEqRefl
   | otherwise    = return v
-  where countUp [] _ = True
+  where countUp [] _       = True
         countUp (i : is) j = i == j && countUp is (j + 1)
 flattenV (VEqThen v1 v2) = foldBinary VEqThen <$> flattenV v1 <*> flattenV v2
 flattenV (VEqLambda v) = foldUnary VEqLambda <$> flattenV v

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE PatternGuards #-}
 module Syntax (module Syntax) where
 
-import           Control.Monad.IO.Class
-import           Data.Bifunctor         (first)
-import           Data.Generics          hiding (GT, TyCon (..))
-import           Data.IORef
-import           GHC.Stack
+import Control.Monad.IO.Class
+import Data.Bifunctor         (first)
+import Data.Generics          hiding (GT, TyCon (..))
+import Data.IORef
+import GHC.Stack
 
 --------------------------------------------------------------------------------
 -- Top-level entities
@@ -338,10 +338,10 @@ shiftIsV vs j n (Known is) = Known (map shiftI is) where
   shiftI (PrArg v) = PrArg v
 
 shiftPNV :: [UVar] -> Int -> Int -> Pred -> Pred
-shiftPNV vs j n (PEq t u) = PEq (shiftTNV vs j n t) (shiftTNV vs j n u)
-shiftPNV vs j n (PLeq y z) = PLeq (shiftTNV vs j n y) (shiftTNV vs j n z)
+shiftPNV vs j n (PEq t u)     = PEq (shiftTNV vs j n t) (shiftTNV vs j n u)
+shiftPNV vs j n (PLeq y z)    = PLeq (shiftTNV vs j n y) (shiftTNV vs j n z)
 shiftPNV vs j n (PPlus x y z) = PPlus (shiftTNV vs j n x) (shiftTNV vs j n y) (shiftTNV vs j n z)
-shiftPNV vs j n (PFold z) = PFold (shiftTNV vs j n z)
+shiftPNV vs j n (PFold z)     = PFold (shiftTNV vs j n z)
 
 shiftT :: Int -> Ty -> Ty
 shiftT j = shiftTN j 1
@@ -366,21 +366,21 @@ data Term =
   deriving (Data, Eq, Show, Typeable)
 
 shiftENV :: [UVar] -> Int -> Int -> Term -> Term
-shiftENV _ _ _ e@(EVar {})   = e
-shiftENV vs j n (ELam x mt e) = ELam x (shiftTNV vs j n <$> mt) (shiftENV vs j n e)
-shiftENV vs j n (EApp f e)    = EApp (shiftENV vs j n f) (shiftENV vs j n e)
-shiftENV vs j n (ETyLam x mk e) = ETyLam x mk (shiftENV vs (j + 1) n e)
-shiftENV vs j n (EPrLam p e) = EPrLam (shiftPNV vs j n p) e
-shiftENV vs j n (EInst e is) = EInst (shiftENV vs j n e) (shiftIsV [] j n is)
-shiftENV vs j n (ESing t) = ESing (shiftTNV vs j n t)
-shiftENV vs j n (ELabel k l e) = ELabel k (shiftENV vs j n l) (shiftENV vs j n e)
+shiftENV _ _ _ e@(EVar {})       = e
+shiftENV vs j n (ELam x mt e)    = ELam x (shiftTNV vs j n <$> mt) (shiftENV vs j n e)
+shiftENV vs j n (EApp f e)       = EApp (shiftENV vs j n f) (shiftENV vs j n e)
+shiftENV vs j n (ETyLam x mk e)  = ETyLam x mk (shiftENV vs (j + 1) n e)
+shiftENV vs j n (EPrLam p e)     = EPrLam (shiftPNV vs j n p) e
+shiftENV vs j n (EInst e is)     = EInst (shiftENV vs j n e) (shiftIsV [] j n is)
+shiftENV vs j n (ESing t)        = ESing (shiftTNV vs j n t)
+shiftENV vs j n (ELabel k l e)   = ELabel k (shiftENV vs j n l) (shiftENV vs j n e)
 shiftENV vs j n (EUnlabel k e l) = EUnlabel k (shiftENV vs j n e) (shiftENV vs j n l)
-shiftENV _ _ _ e@(EConst {}) = e
-shiftENV vs j n (ELet x e f) = ELet x (shiftENV vs j n e) (shiftENV vs j n f)
-shiftENV vs j n (ECast e q) = ECast (shiftENV vs j n e) q
-shiftENV vs j n (ETyped e t) = ETyped e (shiftTNV vs j n t)
+shiftENV _ _ _ e@(EConst {})     = e
+shiftENV vs j n (ELet x e f)     = ELet x (shiftENV vs j n e) (shiftENV vs j n f)
+shiftENV vs j n (ECast e q)      = ECast (shiftENV vs j n e) q
+shiftENV vs j n (ETyped e t)     = ETyped e (shiftTNV vs j n t)
 shiftENV _ _ _ e@(EStringLit {}) = e
-shiftENV _ _ _ e@(EHole {}) = e
+shiftENV _ _ _ e@(EHole {})      = e
 
 shiftEN :: Int -> Int -> Term -> Term
 shiftEN = shiftENV []


### PR DESCRIPTION
This PR proposes formatting the existing haskell files with stylish-haskell, so that I can use it in the future without creating noisy diffs.

@jgbm What do you think about this?
If there's anything about the style that you find particularly upsetting, I can tweak the config. Personally I'm not sure about the padding it adds to unqualified imports.

- **add default stylish-haskell config**
- **format existing files**
