### PR TITLE
add option to print variables with de Bruijn indices

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -29,10 +29,10 @@ import Syntax
 data Flags = Flags { evals :: [String], inputs :: [String], imports :: [String]
                    , doTraceKindInference, doTraceInference
                    , doTraceEvaluation, doPrintTyped, printOkay
-                   , doPrintKinds, doPrintMaps, doPrintInstantiations :: Bool }
+                   , doPrintKinds, doPrintMaps, doPrintInstantiations, doPrintIndices :: Bool }
 
 emptyFlags :: Flags
-emptyFlags = Flags [] [] [] False False False False False False False False
+emptyFlags = Flags [] [] [] False False False False False False False False False
 
 interpretFlags = foldl (flip ($)) emptyFlags
 
@@ -48,6 +48,7 @@ options = [ Option ['e'] ["eval"] (ReqArg (\s f -> f { evals = evals f ++ splitO
           , Option [] ["print-kinds"] (NoArg (\f -> f { doPrintKinds = True })) "print kind information"
           , Option [] ["print-maps"] (NoArg (\f -> f { doPrintMaps = True })) "print maps explicitly"
           , Option [] ["print-instantiations"] (NoArg (\f -> f { doPrintInstantiations = True })) "print instantiations explicitly"
+          , Option [] ["print-indices"] (NoArg (\f -> f { doPrintIndices = True })) "print variables deBruijn indices"
           , Option [] ["reset"] (NoArg (const emptyFlags)) "reset flags" ]
 unprog (Prog ds) = ds
 
@@ -169,5 +170,5 @@ reportErrors flags (Left err) =
 reportErrors _ (Right x) = return x
 
 putDocWLn :: Int -> Flags -> RDoc ann -> IO ()
-putDocWLn n f d = do P.putDocW n =<< runReaderT d (PO {level = 0, printKinds = doPrintKinds f, printMaps = doPrintMaps f, printInstantiations = doPrintInstantiations f})
+putDocWLn n f d = do P.putDocW n =<< runReaderT d (PO {level = 0, printKinds = doPrintKinds f, printMaps = doPrintMaps f, printInstantiations = doPrintInstantiations f, printIndices = doPrintIndices f})
                      putStrLn ""

--- a/src/Printer.hs
+++ b/src/Printer.hs
@@ -142,7 +142,7 @@ instance Printable Ty where
   ppr (TVar n x) = do pi <- asks printIndices
                       if pi
                         then ppr x <> "@" <> ppre n
-                        else ppre n
+                        else ppr x
   ppr (TUnif v) = ppr v
   ppr TFun = "(->)"
   ppr (TThen p t) = fillSep [ppr p <+> "=>", ppr t]

--- a/src/Printer.hs
+++ b/src/Printer.hs
@@ -14,7 +14,7 @@ import System.IO.Unsafe
 
 import Syntax
 
-data PrinterOptions = PO { level :: Int, printKinds :: Bool, printMaps :: Bool, printInstantiations :: Bool }
+data PrinterOptions = PO { level :: Int, printKinds :: Bool, printMaps :: Bool, printInstantiations :: Bool, printIndices :: Bool }
 type RDoc ann = ReaderT PrinterOptions IO (P.Doc ann)
 
 instance Semigroup (RDoc ann) where
@@ -139,7 +139,10 @@ getTupleContents (TLabeled (TLab l) t:ts) n | show n == l = (t:) <$> getTupleCon
 getTupleContents _ _ = Nothing
 
 instance Printable Ty where
-  ppr (TVar _ x) = ppr x
+  ppr (TVar n x) = do pi <- asks printIndices
+                      if pi
+                        then ppr x <> "@" <> ppre n
+                        else ppre n
   ppr (TUnif v) = ppr v
   ppr TFun = "(->)"
   ppr (TThen p t) = fillSep [ppr p <+> "=>", ppr t]
@@ -313,5 +316,5 @@ pprTypeError te = vsep ctxts <> pure P.line <> indent 2 (pprErr te')
 renderString :: RDoc ann -> String
 renderString doc =
   unsafePerformIO $
-  do d <- runReaderT doc (PO {level = 0, printKinds = False, printMaps = False, printInstantiations = True})
+  do d <- runReaderT doc (PO {level = 0, printKinds = False, printMaps = False, printInstantiations = True, printIndices = True})
      return (P.renderString (P.layoutPretty (P.LayoutOptions P.Unbounded) d))


### PR DESCRIPTION
Example of error output with option turned on.

```
  The predicate {inputColumn@4 := v1@2} < r1@2
  is not entailed by {inputColumn@5 := v1@2} < r1@3, {groupColumn@6 := K@7} < r1@3, {groupColumn@6 := K@7} +
    {outputColumn@4 := v2@1} ~ z#89@0
```